### PR TITLE
Add metadata update (filling in a match)

### DIFF
--- a/Cagent.bundle/Contents/Code/utils.py
+++ b/Cagent.bundle/Contents/Code/utils.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+def get_date(s_date):
+    date_patterns = ["%d.%m.%Y", "%Y %m %d", "%Y-%m-%d"]
+
+    for pattern in date_patterns:
+        try:
+            return datetime.strptime(s_date, pattern).date()
+        except:
+            pass
+
+    Log.Info("[" + utils + "] [get_date] Could not format date " + s_date)
+    return None


### PR DESCRIPTION
Implemented the update() method, called when the metadata is refreshed with an ID set.

Fills in title, studio and date from event info table
Fills in summary using information from the event info table and adding the results or card if configured that way
Sets the CAGEMATCH community rating for an event if present
Sets Plex roles for each worker in the All Workers list on the event page
Adds events to collections if configured that way

Extract event search to new method so it can be reused