### PR TITLE
Add option to remove promotion intials from events

### DIFF
--- a/Cagent.bundle/Contents/Code/url_loading.py
+++ b/Cagent.bundle/Contents/Code/url_loading.py
@@ -15,9 +15,8 @@ def simple_get(url):
     text content, otherwise return None.
     """
     try:
+        Log.Debug("[url_loading] Requesting " + str(url))
         with closing(get(url, stream=True, headers = {'Accept-Encoding': 'identity'})) as resp:
-        #with closing(get(url, stream=True)) as resp:
-            Log.Debug("[url_loading] " + str(resp.request.headers))
             if is_good_response(resp):
                 return resp.content
             else:

--- a/Cagent.bundle/Contents/DefaultPrefs.json
+++ b/Cagent.bundle/Contents/DefaultPrefs.json
@@ -62,5 +62,16 @@
 		"label": "Include WON Ratings if available when adding reviews (no effect if reviews are disabled)",
 		"type": "bool",
 		"default": "true"
+	},
+	{
+		"id": "removePromotionSlug",
+		"label": "Remove promotion abbreviaton from event titles: ",
+		"type": "enum",
+		"values": [
+			"Always",
+			"When added to \"Promotion Name\" collection",
+			"Never"
+		],
+		"default": "When added to \"Promotion Name\" collection"
 	}
 ]

--- a/test/test-files.yml
+++ b/test/test-files.yml
@@ -29,3 +29,8 @@ events:
   - "Ice Ribbon - 2019-03-31 - New Ice Ribbon #951 ~ Ice Ribbon March 2019"
   # Test that freelance events work
   - "2017-11-03 - Manami Toyota Produce Manami Toyota 30th Anniversary ~ Retirement To The Universe"
+  # Multiple events from same promotion, used to test collections and slug removal
+  - "ROH - 2002-02-23 - The Era of Honor Begins"
+  - "ROH - 2002-03-30 - Round Robin Challenge"
+  - "ROH - 2002-04-27 - Night of Appreciation"
+  - "ROH - 2002-06-22 - Road To The Title"


### PR DESCRIPTION
Adds a config option allowing promotion abbreviations to be removed
from titles. By default, this is only done when events are added to
collections for the promotion. This can also be done for every event
regardless of collection or disabled entirely.

Also adds some more test files, and changes some logging of GET
requests.