### PR TITLE
Allow for optional whitespace in cm-id search regex

### DIFF
--- a/Cagent.bundle/Contents/Code/__init__.py
+++ b/Cagent.bundle/Contents/Code/__init__.py
@@ -218,7 +218,7 @@ class Cagent_Movie(Agent.Movies):
             search_str = os.path.splitext(os.path.basename(pathname))[0]
         Log.Info("[" + AGENT_NAME + "] [search] Searching for \"" + search_str + "\" " + ("manually" if manual else "automatically"))
         # CM ID Regex tester: https://regex101.com/r/6mNdAe/1
-        manual_id_match = re.match(r'^cm-id:([0-9]+:?-?[0-9]+)$', search_str)
+        manual_id_match = re.match(r'^cm-id:\s?([0-9]+:?-?[0-9]+)$', search_str)
         if manual_id_match:
             self.search_by_cm_id(results, lang, manual_id_match.group(1))
             return


### PR DESCRIPTION
When doing a copy/paste of a CM ID from the web the value will somtimes
paste into the Plex matcher UI with a space between ‘cm-id:’ and the
ID itself.

This should allow for that as an optional part of the regex match and
include it in the “cm-id” part of the regex.

<img width="936" alt="Screen Shot 2022-04-20 at 12 24 51" src="https://user-images.githubusercontent.com/1384/164297610-d04ccf94-6036-4009-8f0d-6ee5b2aaa7f5.png">